### PR TITLE
GPEWindow: Conversion wxString -> std::string fix + typo

### DIFF
--- a/libgdsto3d/gdsparse.cpp
+++ b/libgdsto3d/gdsparse.cpp
@@ -85,7 +85,7 @@ bool GDSParse::Parse(FILE *iptr)
 
 		bool result = ParseFile();
 
-		v_printf(1, "\nSumary:\n\tPaths:\t\t%ld\n\tBoundaries:\t%ld\n\tBoxes:\t\t%ld\n\tStrings:\t%ld\n\tStuctures:\t%ld\n\tArrays:\t\t%ld\n",
+		v_printf(1, "\nSummary:\n\tPaths:\t\t%ld\n\tBoundaries:\t%ld\n\tBoxes:\t\t%ld\n\tStrings:\t%ld\n\tStuctures:\t%ld\n\tArrays:\t\t%ld\n",
 			m_pathelements, m_boundaryelements, m_boxelements, m_textelements, m_srefelements, m_arefelements);
 
 		return result;

--- a/process_editor/gpe_window.cpp
+++ b/process_editor/gpe_window.cpp
@@ -386,8 +386,8 @@ void GPEWindow::OnMenuFileOpen( wxCommandEvent& event )
 			m_process_path.Printf(wxT("%s"), (char *)fileDialog->GetPath().char_str());
 
 			std::string filename;
-			
-			filename = (char *)(m_process_path.c_str());
+
+			filename = std::string(m_process_path.mb_str());
 
 			m_process->Parse(filename);
 			if(m_process->IsValid()){


### PR DESCRIPTION
The file process_editor/gpe_window.cpp needed a minor change to build on my system (wx version 3.0.5.1, gcc 10.2.0). Also, I fixed a small typo.